### PR TITLE
Default selected text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+build/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "find-replace",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ function App() {
           { id: 2, findText: '', replaceText: '', caseSensitive: false },
         ];
   });
-  
+  const [autoFocusControlId, setAutoFocusControlId] = useState(null);
   const textAreaRef = useRef(null);
 
   useEffect(() => {
@@ -56,7 +56,6 @@ function App() {
   };
 
   const addControl = () => {
-    // default "find" field to highlighted text
     let selectedText = '';
     if (textAreaRef.current) {
       const start = textAreaRef.current.selectionStart;
@@ -65,10 +64,12 @@ function App() {
         selectedText = text.substring(start, end);
       }
     }
+    const newId = Date.now();
     setControls([
       ...controls, 
-      { id: Date.now(), findText: selectedText, replaceText: '', caseSensitive: false }
+      { id: newId, findText: selectedText, replaceText: '', caseSensitive: false }
     ]);
+    if(selectedText !== '') setAutoFocusControlId(newId);
 
     // clear highlighted text
     if (textAreaRef.current) {
@@ -89,6 +90,7 @@ function App() {
               onToggleCase={() => toggleCaseSensitive(control.id)}
               onRemove={() => removeControl(control.id)}
               index={index}
+              autoFocusReplace={control.id === autoFocusControlId}
             />
           ))}
           <button onClick={addControl} className="add-button">

--- a/src/App.js
+++ b/src/App.js
@@ -56,7 +56,25 @@ function App() {
   };
 
   const addControl = () => {
-    setControls([...controls, { id: Date.now(), findText: '', replaceText: '', caseSensitive: false }]);
+    // default "find" field to highlighted text
+    let selectedText = '';
+    if (textAreaRef.current) {
+      const start = textAreaRef.current.selectionStart;
+      const end = textAreaRef.current.selectionEnd;
+      if (start !== end) {
+        selectedText = text.substring(start, end);
+      }
+    }
+    setControls([
+      ...controls, 
+      { id: Date.now(), findText: selectedText, replaceText: '', caseSensitive: false }
+    ]);
+
+    // clear highlighted text
+    if (textAreaRef.current) {
+      textAreaRef.current.focus();
+      textAreaRef.current.setSelectionRange(textAreaRef.current.selectionEnd, textAreaRef.current.selectionEnd);
+    }
   };
 
   return (

--- a/src/ControlsSection.js
+++ b/src/ControlsSection.js
@@ -1,7 +1,14 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 
-function ControlsSection({ control, onChange, onRemove, onToggleCase, index }) {
+function ControlsSection({ control, onChange, onRemove, onToggleCase, index, autoFocusReplace }) {
   const { findText, replaceText, caseSensitive } = control;
+  const replaceInputRef = useRef(null);
+
+  useEffect(() => {
+    if (autoFocusReplace && replaceInputRef.current) {
+      replaceInputRef.current.focus();
+    }
+  }, [autoFocusReplace]);
 
   return (
     <div className="controls-section">
@@ -15,6 +22,7 @@ function ControlsSection({ control, onChange, onRemove, onToggleCase, index }) {
       />
       <input
         type="text"
+        ref={replaceInputRef}
         value={replaceText}
         onChange={(e) => onChange('replaceText', e.target.value)}
         placeholder="Replace with"


### PR DESCRIPTION
Selecting text and adding a new find/replace section defaults the Find text to what's selected:

![freescrub-default-find-text](https://github.com/user-attachments/assets/bc576a9d-b92f-46ef-9b13-e1a7e1a9b18c)

Also places focus on the appropriate Replace field.